### PR TITLE
Add Firebase Hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The first step is to enable GitHub Pages on this [repository](https://docs.githu
    > Turning on GitHub Pages creates a deployment of your repository. GitHub Actions may take up to a minute to respond while waiting for the deployment. Future steps will be about 20 seconds; this step is slower.
    > **Note**: In the **Pages** of **Settings**, the **Visit site** button will appear at the top. Click the button to see your GitHub Pages site.
 
+## Publicar en Firebase Hosting
+
+Si prefieres alojar este sitio en Firebase, consulta el archivo
+[`firebase-hosting.md`](./firebase-hosting.md) para conocer los pasos
+básicos de configuración y despliegue.
+
 <footer>
 
 <!--

--- a/firebase-hosting.md
+++ b/firebase-hosting.md
@@ -1,0 +1,31 @@
+# Desplegar en Firebase Hosting
+
+Este repositorio contiene un sitio estático que puede publicarse en Firebase Hosting.
+A continuación se muestran los pasos básicos para ponerlo en línea.
+
+## Requisitos
+
+- Tener instalado [Node.js](https://nodejs.org/) en tu equipo.
+- Instalar la herramienta de línea de comandos de Firebase:
+  ```bash
+  npm install -g firebase-tools
+  ```
+
+## Pasos para el despliegue
+
+1. Inicia sesión en Firebase (solo es necesario la primera vez):
+   ```bash
+   firebase login
+   ```
+2. Inicializa el proyecto dentro del repositorio:
+   ```bash
+   firebase init
+   ```
+   - Selecciona **Hosting** y sigue las instrucciones.
+   - Cuando se te pregunte la carpeta pública, puedes indicar `public` o la carpeta que contenga tu sitio estático.
+3. Una vez configurado, despliega con:
+   ```bash
+   firebase deploy
+   ```
+
+Al finalizar, Firebase mostrará la URL donde se aloja tu sitio.


### PR DESCRIPTION
## Summary
- add section on Firebase Hosting to README
- include standalone guide `firebase-hosting.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68537d10a720832397004d71af788211